### PR TITLE
Sort bed file after converted from bam

### DIFF
--- a/fasticlip/helper.py
+++ b/fasticlip/helper.py
@@ -156,7 +156,7 @@ def run_samtools(samfiles, flags=""):
 		out_bedfiles.append(bedfile)
 				
 		cmd_1 = "cat {} | samtools view {} -Su - -o - | samtools sort - {}".format(samfile, flags, bamfile_sort)
-		cmd_2 = "bamToBed -i {} > {}".format(bamfile_sort + '.bam', bedfile)
+		cmd_2 = "bamToBed -i {} | sort -k1,1 -k2,2n > {}".format(bamfile_sort + '.bam', bedfile)
 		if cfg.verbose: log(cmd_1)
 		os.system(cmd_1)
 		if cfg.verbose: log(cmd_2)


### PR DESCRIPTION
Error from "bedtools intersect" as follow:
ERROR: chromomsome sort ordering for file ./results/MMhur/example_MMhur_R1_trimmed_mappedToGenome_withDupes.bed is inconsistent with other files. Record was:
chr1    3277950 3278012 172503-1    255 -
